### PR TITLE
Add to environment.yml: descartes, intake, nano

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - ctd
   - dask
   - datashader
+  - descartes
   - erddapy
   - geolinks
   - geopandas
@@ -24,6 +25,7 @@ dependencies:
   - h5netcdf
   - holoviews
   - hvplot
+  - intake
   - ioos-tools
   - ioos_qc
   - ipyleaflet
@@ -101,6 +103,7 @@ dependencies:
   - emacs
   - git
   - graphviz
+  - nano
   - unzip
   - vim
   - zip


### PR DESCRIPTION
- `descartes` is used by the geopandas plot method (or some subset of it; I forget). It used to be a direct dependency, but it was separated as an optional dependency some time ago
- It'll be good to have `intake` even if it isn't used in a tutorial (though Chelle might). Could be useful in projects.
- `nano` is much easier to pick up than vim and emacs, IMHO. For people who don't use either vim or emacs (or any other terminal text editor), i think it's more helpful to point them to nano, at least during OHW